### PR TITLE
Reduce rerendering in MeteoScreen_v2 and MeteoScreen_TabDetailed

### DIFF
--- a/src/hooks/customHook.tsx
+++ b/src/hooks/customHook.tsx
@@ -1,0 +1,17 @@
+import { useState, useEffect, useRef } from 'react'
+import _ from 'lodash'
+
+export function useCustomHook<any>(value) {
+	const [state, setState] = useState<any>(value)
+	let prevState = state
+
+	const customSetState = (newState) => {
+		if (!_.isEqual(prevState, newState))
+		{
+			setState(newState)
+			prevState = newState
+		}
+	}
+
+	return [state, customSetState]
+}

--- a/src/screens/meteo_v2/MeteoScreen_TabDetailed.tsx
+++ b/src/screens/meteo_v2/MeteoScreen_TabDetailed.tsx
@@ -19,6 +19,8 @@ import Metrics_v2 from '../../components/v2/Metrics_v2';
 import _ from 'lodash'
 import HygoChart from '../../components/realtime/HygoChart'
 
+import { useCustomHook } from '../../hooks/customHook'
+
 interface detailedType {
 	data: any,
 	products: any,
@@ -48,9 +50,9 @@ const ChartContainer = ({ children, onPress, opened, title }) => {
 
 const MeteoDetailed_v2 = ({ navigation, lastMeteoLoad, meteoSynced, parcelles }) => {
 	const context = React.useContext(MeteoContext)
-	const [loading, setLoading] = useState(true)
-	const [isRefreshing, setIsRefreshing] = useState(false)
-	const [detailed, setDetailed] = useState<detailedType>({} as detailedType)
+	const [loading, setLoading] = useCustomHook(true)
+	const [isRefreshing, setIsRefreshing] = useCustomHook(false)
+	const [detailed, setDetailed] = useCustomHook<detailedType>({} as detailedType)
 	const { dow, currentDay, setCurrentDay } = context
 	const [lastLoad, setLastLoad] = useState(-1)
 	const [counter, setCounter] = useState(0);
@@ -76,7 +78,7 @@ const MeteoDetailed_v2 = ({ navigation, lastMeteoLoad, meteoSynced, parcelles })
 		return ret
 	}, [context.meteo])
 
-	console.log("===MeteoDetailed_v2 rendered")
+	console.log("===MeteoDetailed_v2 rendered", context, 'loading :' , loading, 'isRefreshing :', isRefreshing, 'detailed :', detailed )
 
 	// useEffect(() => {
 	//     let interval
@@ -110,6 +112,7 @@ const MeteoDetailed_v2 = ({ navigation, lastMeteoLoad, meteoSynced, parcelles })
 	// }, [counter])
 
 	useEffect(() => {
+		console.log('im useEffect')
 		loadMeteoDetailed()
 	}, [])
 
@@ -137,11 +140,13 @@ const MeteoDetailed_v2 = ({ navigation, lastMeteoLoad, meteoSynced, parcelles })
 	}
 
 	const onRefresh = async () => {
+		console.log('im onRefresh')
 		setIsRefreshing(true)
 		await Promise.all([
 			loadMeteoDetailed(),
-			context.loadConditions(parcelles.fields),
-			context.loadMeteo(parcelles.fields)
+			context.loadMeteoAndConditions(parcelles.fields)
+			// context.loadConditions(parcelles.fields),
+			// context.loadMeteo(parcelles.fields)
 		])
 		setIsRefreshing(false)
 	}
@@ -539,5 +544,7 @@ const mapStateToProps = (state) => ({
 const mapDispatchToProps = (dispatch, props) => ({
 	meteoSynced: (d) => dispatch(meteoSynced(d))
 })
+
+const MemoizedMeteoDetailed_v2 = React.memo(MeteoDetailed_v2)
 
 export default connect(mapStateToProps, mapDispatchToProps)(MeteoDetailed_v2);

--- a/src/screens/meteo_v2/MeteoScreen_v2.tsx
+++ b/src/screens/meteo_v2/MeteoScreen_v2.tsx
@@ -14,16 +14,19 @@ import { Amplitude, AMPLITUDE_EVENTS } from '../../amplitude'
 import { Colors } from 'react-native/Libraries/NewAppScreen';
 import { MeteoContext } from '../../context/meteo.context';
 import { connect } from 'react-redux'
+import _ from 'lodash'
 
 const MeteoScreen_v2 = ({ navigation, parcelles }) => {
-    const { loadMeteo, loadConditions } = React.useContext(MeteoContext)
+    const { loadMeteo, loadConditions, loadMeteoAndConditions } = React.useContext(MeteoContext)
+	const value = React.useContext(MeteoContext)
     const [currentTab, setCurrentTab] = useState(0)
     const tabs = ["meteoBriefScreen", "meteoDetailedScreen", "meteoRadarScreen"]
-    const switchTab = (i) => {
+		const switchTab = (i) => {
+				console.log('4')
         setCurrentTab(i);
     }
 
-	console.log("===MeteoScreen_v2 rendered")
+	console.log("===MeteoScreen_v2 rendered", value, 'parcelles :', parcelles)
 
 
     useEffect(() => {
@@ -41,9 +44,15 @@ const MeteoScreen_v2 = ({ navigation, parcelles }) => {
     }, [currentTab])
 
     useEffect(() => {
-        loadMeteo(parcelles.fields)
-        loadConditions(parcelles.fields)
-    }, [])
+		if (!_.isEmpty(parcelles))
+			loadMeteoAndConditions(parcelles.fields)
+    }, [parcelles])
+
+	// useEffect(() => {
+	// 	loadMeteo(parcelles.fields)
+	// 	loadConditions(parcelles.fields)
+    // }, [])
+
     return (
         <SafeAreaView style={[styles.statusbar, { backgroundColor: 'black' }]} forceInset={{ top: 'always' }}>
             <StatusBar translucent backgroundColor="transparent" />


### PR DESCRIPTION
MeteoSreen_v2 before: 
<img width="745" alt="meteoScreen_v2_before" src="https://user-images.githubusercontent.com/38225561/115782545-136cab00-a3bc-11eb-9bc5-3fc56b68219f.png">

MeteoScreen_v2 after:
<img width="743" alt="meteoScreen_v2_after" src="https://user-images.githubusercontent.com/38225561/115782568-1b2c4f80-a3bc-11eb-8a83-16999d3292b2.png">

MeteoScreen_v2 Solution: 
- Manage to reduce rerendering by combining loadMeteo and loadCondition which resulted in a single setState compared to the previous 3x setState
- Add useEffect dependancy (parcelles) so the loading of Meteo and Condition only happened when parcelles is ready
- useMemo on MeteoContext Value, (Result unable tested, Expected Result : Should only rerender when the value change)

MeteoScreen_TabDetailed Solution:
- Create CustomHook which check the prevState vs newState and only setState if they are not the same, this will reduce unnecessary rerender
